### PR TITLE
Using CharSequence over String in get(String)

### DIFF
--- a/src/main/groovy/com/stehno/ersatz/Expectations.groovy
+++ b/src/main/groovy/com/stehno/ersatz/Expectations.groovy
@@ -95,7 +95,7 @@ interface Expectations {
      * @param path the expected request path
      * @return a <code>Request</code> configuration object
      */
-    Request get(String path)
+    Request get(CharSequence path)
 
     /**
      * Allows configuration of a GET request expectation.

--- a/src/main/groovy/com/stehno/ersatz/impl/ExpectationsImpl.groovy
+++ b/src/main/groovy/com/stehno/ersatz/impl/ExpectationsImpl.groovy
@@ -97,8 +97,8 @@ class ExpectationsImpl implements Expectations {
     }
 
     @Override
-    Request get(final String path) {
-        get pathMatcher(path)
+    Request get(final CharSequence path) {
+        get pathMatcher(path?.toString())
     }
 
     @Override

--- a/src/test/groovy/com/stehno/ersatz/issues/ScopingAndAutoCleanupSpec.groovy
+++ b/src/test/groovy/com/stehno/ersatz/issues/ScopingAndAutoCleanupSpec.groovy
@@ -92,7 +92,7 @@ class ScopingAndAutoCleanupSpec extends Specification {
         setup:
         server.expectations {
             post('/posting').body(INPUT_CONTENT, TEXT_PLAIN).decoder(TEXT_PLAIN, utf8String)
-                .responds().body(OUTPUT_CONTENT, TEXT_PLAIN)
+                    .responds().body(OUTPUT_CONTENT, TEXT_PLAIN)
         }
 
         when:
@@ -105,29 +105,20 @@ class ScopingAndAutoCleanupSpec extends Specification {
         server.expectations.requests.size() == 1
     }
 
-    /**
-     * Example how any missing property is converted into `get(name)` expectation.
-     */
-    @Issue('https://github.com/cjstehno/ersatz/issues/110')
-    void 'Posting Four'() {
-        setup:
-            server.expectations {
-                post(('/' + itsAKindOfMagic).trim()) {
-                    body INPUT_CONTENT, TEXT_PLAIN
-                    decoder TEXT_PLAIN, utf8String
-                    responder {
-                        body OUTPUT_CONTENT, TEXT_PLAIN
-                    }
+    void 'Usage of unknown property should throw exception'() {
+        when:
+        server.expectations {
+            post(('/' + itsAKindOfMagic).trim()) {
+                body INPUT_CONTENT, TEXT_PLAIN
+                decoder TEXT_PLAIN, utf8String
+                responder {
+                    body OUTPUT_CONTENT, TEXT_PLAIN
                 }
             }
-
-        when:
-            Response response = client.post(server.httpUrl('/Expectations (ErsatzRequest): <GET>, "itsAKindOfMagic",'), create(get('text/plain; charset=utf-8'), INPUT_CONTENT))
+        }
 
         then:
-            response.body().string() == OUTPUT_CONTENT
-
-        and:
-            server.expectations.requests.size() == 2
+        def e = thrown(MissingPropertyException)
+        e.property == "itsAKindOfMagic"
     }
 }


### PR DESCRIPTION
An example change to limit some confusing errors caused by `get(String)`.

Why not to use CharSequence everywhere? Don't want to change everything and equality of GStrings is a bit suprising when casting is involved.

For instance:
```groovy
def a = "foo"
def b = "foo"
assert a == "$a"
assert "$a" == "$a"
assert "$a" == "$b"
// but
assert ((CharSequence)"a") != ((CharSequence)"$b")
```

Essentially, GString is being automatically converted to String when String is being used but it is not converted when CharSequence is being used. So it would not be equal to equivalent String anymore (wrong type).

Hence if one want to use CharSequence in API first thing to do is to convert it to String. 