### PR TITLE
Do not export Groovy as a dependency

### DIFF
--- a/ersatz-groovy/build.gradle
+++ b/ersatz-groovy/build.gradle
@@ -23,13 +23,16 @@ repositories {
 
 dependencies {
     implementation project(':ersatz')
-    implementation "org.apache.groovy:groovy:$groovyVersion"
-    implementation "org.apache.groovy:groovy-json:$groovyVersion"
+    
+    compileOnly "org.apache.groovy:groovy:$groovyVersion"
+    compileOnly "org.apache.groovy:groovy-json:$groovyVersion"
 
     testImplementation 'io.github.cjstehno:test-things:0.1.0'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testImplementation "org.apache.groovy:groovy:$groovyVersion"
+    testImplementation "org.apache.groovy:groovy-json:$groovyVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }
 


### PR DESCRIPTION
If the developers are using Groovy, they already have the dependency on the classpath. Not exporting Groovy dependency helps to resolve the issue of using Ersatz with Groovy 3.x because otherwise there is a conflict between the Groovy 3.x and Groovy 4.x on the classpath.