### PR TITLE
Switch `ersatz` to `api` configuration for `ersatz-groovy`

### DIFF
--- a/ersatz-groovy/build.gradle
+++ b/ersatz-groovy/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':ersatz')
+    api project(':ersatz')
     
     compileOnly "org.apache.groovy:groovy:$groovyVersion"
     compileOnly "org.apache.groovy:groovy-json:$groovyVersion"


### PR DESCRIPTION
Resolves #197